### PR TITLE
Version 0.0.2.

### DIFF
--- a/ConsumerGroupLag/build.gradle
+++ b/ConsumerGroupLag/build.gradle
@@ -16,14 +16,14 @@ apply plugin: 'com.github.johnrengelman.shadow'
 jar {
     manifest {
         attributes 'Main-Class': mainClassName,
-        'Implementation-Version': '0.0.1',
+        'Implementation-Version': '0.0.2',
         'Implementation-Title': 'ConsumerGroupLag'
     }
 }
 
 shadowJar {
    baseName = 'ConsumerGroupLag'
-   version = '0.0.1'
+   version = '0.0.2'
 }
 
 repositories {
@@ -31,8 +31,8 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'org.apache.kafka', name: 'kafka-clients', version: "0.10.2.0")
-    compile(group: 'org.apache.kafka', name: 'kafka_2.11', version: "0.10.2.0")
+    compile(group: 'org.apache.kafka', name: 'kafka-clients', version: "0.11.0.1")
+    compile(group: 'org.apache.kafka', name: 'kafka_2.11', version: "0.11.0.1")
     compile(group: 'commons-cli', name: 'commons-cli', version: "1.3.1");
     compile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "2.6.3")
     compile(group: 'log4j', name: 'log4j', version: "1.2.17")


### PR DESCRIPTION
Upgrade to kafka-clients 0.11.0.1.

Add optional argument -t,--group-stabilization-timeout, time in ms to wait for the consumer group description to be avaialble (e.g. wait for a consumer group rebalance to complete).

Output the consumer group state to stderr if it's not "Dead" or "Stable".